### PR TITLE
Fix NeighborsTable pagination display bug

### DIFF
--- a/client/js/components/neighbors/NeighborsTable.jsx
+++ b/client/js/components/neighbors/NeighborsTable.jsx
@@ -141,7 +141,7 @@ export default class NeighborsTable extends React.Component {
     shouldDisplayClickable(index) {
         return index === 0
             || index === this.state.neighbors.length - 1
-            || Math.abs(index, this.state.currentChunk) <= 1;
+            || Math.abs(index - this.state.currentChunk) <= 1;
     }
 
 }


### PR DESCRIPTION
If neighbors can be split into 10 different table pages and the user is currently viewing page 6, the following page links should be clickable: 1,5,6,7,10, i.e. [first],[current-1],[current],[current+1],[last].